### PR TITLE
fix android webview 里 html font-size 因设置系统字体大小受到影响

### DIFF
--- a/src/flexible.js
+++ b/src/flexible.js
@@ -72,6 +72,11 @@
         }
         var rem = width / 10;
         docEl.style.fontSize = rem + 'px';
+        var realitySize = parseInt(window.getComputedStyle(document.documentElement).fontSize);
+        if (rem !== realitySize) {
+            rem = rem * rem / realitySize;
+            docEl.style.fontSize = rem + 'px';
+        }
         flexible.rem = win.rem = rem;
     }
 


### PR DESCRIPTION
如题
比如font-size本来是36px，但因设置系统的字体大小，导致实际的font-size不等于36px。
